### PR TITLE
レコメンド機能の実装 #45

### DIFF
--- a/backend/app/controllers/api/v1/playlists_controller.rb
+++ b/backend/app/controllers/api/v1/playlists_controller.rb
@@ -67,6 +67,19 @@ module Api
         Rails.logger.info "Rendering playlist with #{community.playlist_tunes.count} tunes."
         render json: @playlists
       end
+
+      # プレイリストの曲をレコメンドする
+      def create_recommend
+        tune = Tune.find_by(id: params[:tune_id])
+        community = Community.find_by(id: params[:community_id])
+        playlist_tune = Playlist.find_by(tune_id: tune.id, community_id: community.id)
+        if playlist_tune.update(recommend: true)
+          @playlists = community.playlist_tunes.order(added_at: :desc)
+          render json: @playlists
+        else
+          render json: playlist_tune.errors, status: :unprocessable_entity
+        end
+      end
     end
   end
 end

--- a/backend/app/controllers/api/v1/playlists_controller.rb
+++ b/backend/app/controllers/api/v1/playlists_controller.rb
@@ -67,17 +67,25 @@ module Api
           end
         end
 
-        @playlists = community.playlist_tunes.joins(:playlists).where(playlists: { community_id: community.id }).order(added_at: :desc)
+        @playlists = community.playlist_tunes.with_recommend.order(added_at: :desc)
+
+        # デバッグ用のログを追加
+        Rails.logger.debug "Filtered playlists: #{@playlists.map(&:attributes)}"
+
         Rails.logger.info "Rendering playlist with #{community.playlist_tunes.count} tunes."
-        render json: @playlists.as_json(include: { playlists: { only: [:id, :name, :recommend] } })
+        render json: @playlists.as_json
       end
 
       # プレイリストの曲をレコメンドする
       def create_recommend
         if @playlist_tune.update(recommend: true)
-          @playlists = @community.playlist_tunes.joins(:playlists).where(playlists: { community_id: @community.id }).order(added_at: :desc)
-          Rails.logger.info "Rendering playlist with #{@community.playlist_tunes.count} tunes."
-          render json: @playlists.as_json(include: { playlists: { only: [:id, :name, :recommend] } })
+          @playlists = @community.playlist_tunes.with_recommend.order(added_at: :desc)
+
+        # デバッグ用のログを追加
+        Rails.logger.debug "Filtered playlists: #{@playlists.map(&:attributes)}"
+
+        Rails.logger.info "Rendering playlist with #{@community.playlist_tunes.count} tunes."
+        render json: @playlists.as_json
         else
           render json: @playlist_tune.errors, status: :unprocessable_entity
         end
@@ -86,9 +94,13 @@ module Api
       # プレイリストの曲をアンレコメンドする
       def destroy_recommend
         if @playlist_tune.update(recommend: false)
-          @playlists = community.playlist_tunes.joins(:playlists).where(playlists: { community_id: community.id }).order(added_at: :desc)
-          Rails.logger.info "Rendering playlist with #{community.playlist_tunes.count} tunes."
-          render json: @playlists.as_json(include: { playlists: { only: [:id, :name, :recommend] } })
+          @playlists = @community.playlist_tunes.with_recommend.order(added_at: :desc)
+
+        # デバッグ用のログを追加
+        Rails.logger.debug "Filtered playlists: #{@playlists.map(&:attributes)}"
+
+        Rails.logger.info "Rendering playlist with #{@community.playlist_tunes.count} tunes."
+        render json: @playlists.as_json
         else
           render json: @playlist_tune.errors, status: :unprocessable_entity
         end

--- a/backend/app/controllers/api/v1/playlists_controller.rb
+++ b/backend/app/controllers/api/v1/playlists_controller.rb
@@ -70,7 +70,7 @@ module Api
         @playlists = community.playlist_tunes.with_recommend.order(added_at: :desc)
 
         # デバッグ用のログを追加
-        Rails.logger.debug "Filtered playlists: #{@playlists.map(&:attributes)}"
+        Rails.logger.debug { "Filtered playlists: #{@playlists.map(&:attributes)}" }
 
         Rails.logger.info "Rendering playlist with #{community.playlist_tunes.count} tunes."
         render json: @playlists.as_json
@@ -81,11 +81,11 @@ module Api
         if @playlist_tune.update(recommend: true)
           @playlists = @community.playlist_tunes.with_recommend.order(added_at: :desc)
 
-        # デバッグ用のログを追加
-        Rails.logger.debug "Filtered playlists: #{@playlists.map(&:attributes)}"
+          # デバッグ用のログを追加
+          Rails.logger.debug { "Filtered playlists: #{@playlists.map(&:attributes)}" }
 
-        Rails.logger.info "Rendering playlist with #{@community.playlist_tunes.count} tunes."
-        render json: @playlists.as_json
+          Rails.logger.info "Rendering playlist with #{@community.playlist_tunes.count} tunes."
+          render json: @playlists.as_json
         else
           render json: @playlist_tune.errors, status: :unprocessable_entity
         end
@@ -96,11 +96,11 @@ module Api
         if @playlist_tune.update(recommend: false)
           @playlists = @community.playlist_tunes.with_recommend.order(added_at: :desc)
 
-        # デバッグ用のログを追加
-        Rails.logger.debug "Filtered playlists: #{@playlists.map(&:attributes)}"
+          # デバッグ用のログを追加
+          Rails.logger.debug { "Filtered playlists: #{@playlists.map(&:attributes)}" }
 
-        Rails.logger.info "Rendering playlist with #{@community.playlist_tunes.count} tunes."
-        render json: @playlists.as_json
+          Rails.logger.info "Rendering playlist with #{@community.playlist_tunes.count} tunes."
+          render json: @playlists.as_json
         else
           render json: @playlist_tune.errors, status: :unprocessable_entity
         end
@@ -120,9 +120,7 @@ module Api
       def find_playlist_tune
         @playlist_tune = Playlist.find_by(tune_id: @tune.id, community_id: @community.id)
 
-        if @playlist_tune.nil?
-          render json: { error: "Playlist tune not found" }, status: :unprocessable_entity
-        end
+        render json: { error: "Playlist tune not found" }, status: :unprocessable_entity if @playlist_tune.nil?
       end
     end
   end

--- a/backend/app/models/community.rb
+++ b/backend/app/models/community.rb
@@ -4,7 +4,7 @@ class Community < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :members, through: :memberships, source: :user
   has_many :playlists, dependent: :destroy
-  has_many :playlist_tunes, through: :playlists, source: :tune
+  has_many :playlist_tunes, -> { order('playlists.recommend DESC') }, through: :playlists, source: :tune
   has_many :comments, dependent: :destroy
 
   validates :name,    presence: true, length: { maximum: 40 }

--- a/backend/app/models/community.rb
+++ b/backend/app/models/community.rb
@@ -4,12 +4,12 @@ class Community < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :members, through: :memberships, source: :user
   has_many :playlists, dependent: :destroy
-  has_many :playlist_tunes, -> {
+  has_many :playlist_tunes, lambda {
     order(
       Arel.sql('playlists.recommend DESC,
       CASE WHEN playlists.recommend
       THEN playlists.updated_at
-      ELSE playlists.created_at END DESC')
+      ELSE tunes.added_at END DESC')
     )
   }, through: :playlists, source: :tune do
     def with_recommend
@@ -24,7 +24,6 @@ class Community < ApplicationRecord
 
   # プレイリストの曲数を返す
   delegate :count, to: :playlist_tunes, prefix: true
-
 
   # アバターURLをS3のURLに更新
   def update_avatar_url

--- a/backend/app/models/playlist.rb
+++ b/backend/app/models/playlist.rb
@@ -2,7 +2,7 @@ class Playlist < ApplicationRecord
   belongs_to :tune
   belongs_to :community
 
-  scope :active, -> { where(active: true) }
+  scope :recommend, -> { where(recommend: true) }
 
   validates :tune_id, uniqueness: { scope: :community_id }
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
         delete :memberships, to: 'memberships#destroy'
         resources :playlists, only: [:index]
         post 'playlists/:tune_id', to: 'playlists#create_recommend'
+        delete 'playlists/:tune_id', to: 'playlists#destroy_recommend'
         get 'tunes/:tune_id/comments', to: 'comments#index'
         post 'tunes/:tune_id/users/:user_id/comments', to: 'comments#create'
         delete 'tunes/:tune_id/users/:user_id/comments/:id', to: 'comments#destroy'

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
         resources :memberships, only: [:create]
         delete :memberships, to: 'memberships#destroy'
         resources :playlists, only: [:index]
+        post 'playlists/:tune_id', to: 'playlists#create_recommend'
         get 'tunes/:tune_id/comments', to: 'comments#index'
         post 'tunes/:tune_id/users/:user_id/comments', to: 'comments#create'
         delete 'tunes/:tune_id/users/:user_id/comments/:id', to: 'comments#destroy'

--- a/backend/db/migrate/20240809124519_rename_active_to_recommend_in_playlists.rb
+++ b/backend/db/migrate/20240809124519_rename_active_to_recommend_in_playlists.rb
@@ -1,0 +1,5 @@
+class RenameActiveToRecommendInPlaylists < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :playlists, :active, :recommend
+  end
+end

--- a/backend/db/migrate/20240811031926_add_default_to_recommend_in_playlists.rb
+++ b/backend/db/migrate/20240811031926_add_default_to_recommend_in_playlists.rb
@@ -1,0 +1,5 @@
+class AddDefaultToRecommendInPlaylists < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :playlists, :recommend, false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_09_071509) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_09_124519) do
   create_table "checks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "tune_id", null: false
@@ -66,7 +66,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_09_071509) do
   create_table "playlists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id", null: false
     t.bigint "tune_id", null: false
-    t.boolean "active"
+    t.boolean "recommend"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["community_id", "tune_id"], name: "index_playlists_on_community_id_and_tune_id", unique: true

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_09_124519) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_11_031926) do
   create_table "checks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "tune_id", null: false
@@ -66,7 +66,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_09_124519) do
   create_table "playlists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id", null: false
     t.bigint "tune_id", null: false
-    t.boolean "recommend"
+    t.boolean "recommend", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["community_id", "tune_id"], name: "index_playlists_on_community_id_and_tune_id", unique: true

--- a/backend/db/scripts/update_recommend_default.rb
+++ b/backend/db/scripts/update_recommend_default.rb
@@ -1,0 +1,1 @@
+Playlist.where(recommend: nil).update_all(recommend: false)

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -8,6 +8,9 @@ if [ "$RAILS_ENV" = "production" ]; then
 
   bundle exec rails db:migrate RAILS_ENV=production
 
+  # 既存のレコードにデフォルト値を設定するスクリプトを実行
+  bundle exec rails runner "Playlist.where(recommend: nil).update_all(recommend: false)"
+
   # DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:reset RAILS_ENV=production
 fi
 

--- a/backend/spec/factories/playlists.rb
+++ b/backend/spec/factories/playlists.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :playlist do
     community
     tune
-    active { false }
+    recommend { false }
   end
 end

--- a/backend/spec/models/community_spec.rb
+++ b/backend/spec/models/community_spec.rb
@@ -63,12 +63,30 @@ RSpec.describe Community, type: :model do
       # Add more validation tests here
     end
 
-    # describe 'associations' do
-    #   # Add association tests here
-    # end
+    describe 'associations' do
+      it 'reflects correct association macro for playlist_tunes' do
+        expect(Community.reflect_on_association(:playlist_tunes).macro).to eq(:has_many)
+      end
 
-    # describe 'methods' do
-    #   # Add method tests here
-    # end
+      it 'reflects correct association through option for playlist_tunes' do
+        expect(Community.reflect_on_association(:playlist_tunes).options[:through]).to eq(:playlists)
+      end
+
+      it 'reflects correct association source option for playlist_tunes' do
+        expect(Community.reflect_on_association(:playlist_tunes).options[:source]).to eq(:tune)
+      end
+    end
+
+    describe 'scopes' do
+      let!(:community) { create(:community) }
+      let!(:playlist1) { create(:playlist, community: community, recommend: true) }
+      let!(:playlist2) { create(:playlist, community: community, recommend: false) }
+      let!(:tune1) { create(:tune, playlists: [playlist1]) }
+      let!(:tune2) { create(:tune, playlists: [playlist2]) }
+
+      it 'orders playlist_tunes by recommend DESC' do
+        expect(community.playlist_tunes).to eq([tune1, tune2])
+      end
+    end
   end
 end

--- a/backend/spec/models/community_spec.rb
+++ b/backend/spec/models/community_spec.rb
@@ -79,13 +79,15 @@ RSpec.describe Community, type: :model do
 
     describe 'scopes' do
       let!(:community) { create(:community) }
-      let!(:playlist1) { create(:playlist, community: community, recommend: true) }
-      let!(:playlist2) { create(:playlist, community: community, recommend: false) }
-      let!(:tune1) { create(:tune, playlists: [playlist1]) }
-      let!(:tune2) { create(:tune, playlists: [playlist2]) }
+      let(:recommend_playlist) { create(:playlist, community: community, recommend: true) }
+      let(:non_recommend_playlist) { create(:playlist, community: community, recommend: false) }
+      let!(:recommend_tune) { create(:tune, playlists: [recommend_playlist]) }
+      let!(:non_recommend_tune) { create(:tune, playlists: [non_recommend_playlist]) }
 
       it 'orders playlist_tunes by recommend DESC' do
-        expect(community.playlist_tunes).to eq([tune1, tune2])
+        recommend_playlist
+        non_recommend_playlist
+        expect(community.playlist_tunes).to eq([recommend_tune, non_recommend_tune])
       end
     end
   end

--- a/backend/spec/requests/playlist_spec.rb
+++ b/backend/spec/requests/playlist_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Playlist, type: :request do
 
       it "returns the correct number of playlists" do
         post "/api/v1/communities/#{community.id}/playlists/#{tune.id}"
-        expect(JSON.parse(response.body).size).to eq(community.playlist_tunes.count)
+        expect(response.parsed_body.size).to eq(community.playlist_tunes.count)
       end
 
       it "updates the recommendation to be truthy" do
@@ -51,7 +51,7 @@ RSpec.describe Playlist, type: :request do
 
       it "returns the correct error message" do
         post "/api/v1/communities/#{community.id}/playlists/9999999"
-        expect(JSON.parse(response.body)).to eq("error"=>"Tune or Community not found")
+        expect(response.parsed_body).to eq("error" => "Tune or Community not found")
       end
     end
   end
@@ -70,7 +70,7 @@ RSpec.describe Playlist, type: :request do
 
       it "returns the correct number of playlists" do
         delete "/api/v1/communities/#{community.id}/playlists/#{tune.id}"
-        expect(JSON.parse(response.body).size).to eq(community.playlist_tunes.count)
+        expect(response.parsed_body.size).to eq(community.playlist_tunes.count)
       end
 
       it "updates the recommendation to be falsy" do
@@ -87,7 +87,7 @@ RSpec.describe Playlist, type: :request do
 
       it "returns the correct error message" do
         delete "/api/v1/communities/#{community.id}/playlists/9999999"
-        expect(JSON.parse(response.body)).to eq("error"=>"Tune or Community not found")
+        expect(response.parsed_body).to eq("error" => "Tune or Community not found")
       end
     end
   end

--- a/backend/spec/requests/playlist_spec.rb
+++ b/backend/spec/requests/playlist_spec.rb
@@ -19,4 +19,32 @@ RSpec.describe Playlist, type: :request do
       expect(playlist[0]['added_at']).to be > playlist[1]['added_at']
     end
   end
+
+  # create_recommendアクションのテスト
+  describe 'POST /api/v1/communities/:community_id/playlists/:tune_id' do
+    let(:tune) { create(:tune) }
+    let(:community) { create(:community) }
+    let!(:playlist_tune) { create(:playlist, tune: tune, community: community) }
+
+    context "when the recommendation is successful" do
+      it "updates the recommendation and returns the playlists" do
+        post "/api/v1/communities/#{community.id}/playlists/#{tune.id}",
+        params: { tune_id: tune.id, community_id: community.id }
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body).size).to eq(community.playlist_tunes.count)
+        expect(playlist_tune.reload.recommend).to be_truthy
+      end
+    end
+
+    context "when the recommendation fails" do
+      it "returns an error message" do
+        post "/api/v1/communities/#{community.id}/playlists/#{tune.id}",
+        params: { tune_id: tune.id, community_id: community.id }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)).to eq(["Error message"])
+      end
+    end
+  end
 end

--- a/frontend/app/src/api/playlistsRecommend.js
+++ b/frontend/app/src/api/playlistsRecommend.js
@@ -1,0 +1,7 @@
+import axios from "axios";
+import { playlistsRecommend } from "@/urls/index";
+
+export const createRecommend = ({ communityId, tuneId }) => {
+  const url = playlistsRecommend(communityId, tuneId);
+  return axios.post(url, {}, { withCredentials: true });
+};

--- a/frontend/app/src/api/playlistsUnrecommend.js
+++ b/frontend/app/src/api/playlistsUnrecommend.js
@@ -1,0 +1,7 @@
+import axios from "axios";
+import { playlistsUnrecommend } from "@/urls/index";
+
+export const destroyRecommend = ({ communityId, tuneId }) => {
+  const url = playlistsUnrecommend(communityId, tuneId);
+  return axios.delete(url, {}, { withCredentials: true });
+};

--- a/frontend/app/src/components/ui/TuneColumn/TuneColumn.jsx
+++ b/frontend/app/src/components/ui/TuneColumn/TuneColumn.jsx
@@ -18,6 +18,8 @@ import { CheckColorIcon } from "../ColorIcon/CheckColorIcon";
 import { useCheck } from "@/hooks/useCheck";
 import { useCheckDelete } from "@/hooks/useCheckDelete";
 import { faSpotify } from "@fortawesome/free-brands-svg-icons";
+import { useRecommend } from "@/hooks/useRecommend";
+import { useParams } from "react-router-dom";
 
 export const TuneColumn = ({ tune, index, onClick }) => {
   if (!tune) {
@@ -110,6 +112,24 @@ export const TuneColumn = ({ tune, index, onClick }) => {
   const checkDelete = useCheckDelete();
   const handleCheckDelete = () => {
     checkDelete.mutate({ userId: user.id, spotify_uri: tune.spotify_uri });
+  };
+
+  // レコメンド機能の実装
+  const recommendValue =
+    tune.playlists && tune.playlists.length > 0
+      ? tune.playlists[0].recommend
+      : null;
+
+  // urlに含まれるcommunity_idを取得
+  const { communityId } = useParams();
+
+  const recommendTune = useRecommend();
+  const handleRecommendCreate = () => {
+    if (user) {
+      recommendTune.mutate({ communityId: communityId, tuneId: tune.id });
+    } else {
+      alert("レコメンド機能はログイン後にご利用いただけます");
+    }
   };
 
   // spotifyのリンクをクリックした際に、外部リンクを開く
@@ -217,10 +237,13 @@ export const TuneColumn = ({ tune, index, onClick }) => {
               onClick={isTuneChecked ? handleCheckDelete : handleCheckCreate}
             />
             {/* レコメンドボタン */}
-            <FontAwesomeIcon
+            <CheckColorIcon
               icon={faThumbsUp}
-              className="h-4 w-4 cursor-pointer text-theme-white"
-              onClick={() => alert("レコメンド機能は現在開発中です")}
+              // className="h-4 w-4 cursor-pointer text-theme-white"
+              isTuneChecked={recommendValue}
+              // onClick={() => alert("レコメンド機能は現在開発中です")}
+              onClick={handleRecommendCreate}
+              // onClick={recommendValue ? handleRecommendDelete : handleRecommendCreate}
             />
             {/* コメントボタン */}
             <FontAwesomeIcon
@@ -269,6 +292,7 @@ TuneColumn.propTypes = {
     time: PropTypes.string.isRequired,
     spotify_uri: PropTypes.string.isRequired,
     external_url: PropTypes.string,
+    playlists: PropTypes.array,
   }),
   index: PropTypes.number.isRequired,
   onClick: PropTypes.func.isRequired,

--- a/frontend/app/src/components/ui/TuneColumn/TuneColumn.jsx
+++ b/frontend/app/src/components/ui/TuneColumn/TuneColumn.jsx
@@ -20,6 +20,8 @@ import { useCheckDelete } from "@/hooks/useCheckDelete";
 import { faSpotify } from "@fortawesome/free-brands-svg-icons";
 import { useRecommend } from "@/hooks/useRecommend";
 import { useParams } from "react-router-dom";
+// import { i } from "vite/dist/node/types.d-aGj9QkWt";
+import { useRecommendDelete } from "@/hooks/useRecommendDelete";
 
 export const TuneColumn = ({ tune, index, onClick }) => {
   if (!tune) {
@@ -115,18 +117,26 @@ export const TuneColumn = ({ tune, index, onClick }) => {
   };
 
   // レコメンド機能の実装
-  const recommendValue =
-    tune.playlists && tune.playlists.length > 0
-      ? tune.playlists[0].recommend
-      : null;
+  const recommendValue = tune.recommend ? true : false;
 
   // urlに含まれるcommunity_idを取得
   const { communityId } = useParams();
 
-  const recommendTune = useRecommend();
+  // 曲をレコメンドする
+  const recommendTune = useRecommend(communityId);
   const handleRecommendCreate = () => {
     if (user) {
       recommendTune.mutate({ communityId: communityId, tuneId: tune.id });
+    } else {
+      alert("レコメンド機能はログイン後にご利用いただけます");
+    }
+  };
+
+  // 曲をレコメンド解除する
+  const recommendDelete = useRecommendDelete(communityId);
+  const handleRecommendDelete = () => {
+    if (user) {
+      recommendDelete.mutate({ communityId: communityId, tuneId: tune.id });
     } else {
       alert("レコメンド機能はログイン後にご利用いただけます");
     }
@@ -242,8 +252,10 @@ export const TuneColumn = ({ tune, index, onClick }) => {
               // className="h-4 w-4 cursor-pointer text-theme-white"
               isTuneChecked={recommendValue}
               // onClick={() => alert("レコメンド機能は現在開発中です")}
-              onClick={handleRecommendCreate}
-              // onClick={recommendValue ? handleRecommendDelete : handleRecommendCreate}
+              // onClick={handleRecommendCreate}
+              onClick={
+                recommendValue ? handleRecommendDelete : handleRecommendCreate
+              }
             />
             {/* コメントボタン */}
             <FontAwesomeIcon
@@ -292,7 +304,7 @@ TuneColumn.propTypes = {
     time: PropTypes.string.isRequired,
     spotify_uri: PropTypes.string.isRequired,
     external_url: PropTypes.string,
-    playlists: PropTypes.array,
+    recommend: PropTypes.bool,
   }),
   index: PropTypes.number.isRequired,
   onClick: PropTypes.func.isRequired,

--- a/frontend/app/src/components/ui/TuneTable/TuneTable.jsx
+++ b/frontend/app/src/components/ui/TuneTable/TuneTable.jsx
@@ -203,6 +203,7 @@ export const TuneTable = () => {
                     ...tune,
                     id: tune.id.toString(),
                     time: tune.time.toString(),
+                    recommend: !!tune.recommend,
                   }}
                   index={index}
                   key={index.toString()}

--- a/frontend/app/src/hooks/useRecommend.js
+++ b/frontend/app/src/hooks/useRecommend.js
@@ -1,0 +1,28 @@
+import { useMutation } from "@tanstack/react-query";
+import { useAtom } from "jotai";
+import axios from "axios";
+import { userAtom } from "@/atoms/userAtoms";
+import { createRecommend } from "@/api/playlistsRecommend";
+import { playlistAtom } from "@/atoms/playlistAtom";
+
+export const useRecommend = () => {
+  const [user] = useAtom(userAtom);
+  const [, setCurrentPlaylist] = useAtom(playlistAtom);
+
+  return useMutation({
+    mutationFn: createRecommend,
+    onSuccess: (data) => {
+      if (user) {
+        setCurrentPlaylist(data);
+        console.log("Recommend success");
+      }
+    },
+    onError: (error) => {
+      if (axios.isCancel(error)) {
+        console.log("Request was canceled by the user");
+      } else {
+        console.error(error);
+      }
+    },
+  });
+};

--- a/frontend/app/src/hooks/useRecommendDelete.js
+++ b/frontend/app/src/hooks/useRecommendDelete.js
@@ -1,12 +1,12 @@
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import axios from "axios";
-import { createRecommend } from "@/api/playlistsRecommend";
+import { destroyRecommend } from "@/api/playlistsUnrecommend";
 
-export const useRecommend = (communityId) => {
+export const useRecommendDelete = (communityId) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: createRecommend,
+    mutationFn: destroyRecommend,
     onSuccess: (data) => {
       if (data.status === 200) {
         // playlistデータを最新のデータで更新
@@ -16,7 +16,7 @@ export const useRecommend = (communityId) => {
           "playlist",
           communityId,
         ]);
-        console.log("Recommend success:", currentPlaylist);
+        console.log("Recommend delete:", currentPlaylist);
       }
     },
     onError: (error) => {

--- a/frontend/app/src/urls/index.js
+++ b/frontend/app/src/urls/index.js
@@ -21,6 +21,9 @@ export const communitiesUpdateAvatar = (communityId) =>
 // プレイリスト一覧
 export const playlistsIndex = (communityId) =>
   `${baseURL}/communities/${communityId}/playlists`;
+// レコメンドする
+export const playlistsRecommend = (communityId, tuneId) =>
+  `${baseURL}/communities/${communityId}/playlists/${tuneId}`;
 
 // コミュニティへ参加
 export const membershipsCreate = (communityId) =>

--- a/frontend/app/src/urls/index.js
+++ b/frontend/app/src/urls/index.js
@@ -24,6 +24,9 @@ export const playlistsIndex = (communityId) =>
 // レコメンドする
 export const playlistsRecommend = (communityId, tuneId) =>
   `${baseURL}/communities/${communityId}/playlists/${tuneId}`;
+// レコメンドを解除する
+export const playlistsUnrecommend = (communityId, tuneId) =>
+  `${baseURL}/communities/${communityId}/playlists/${tuneId}`;
 
 // コミュニティへ参加
 export const membershipsCreate = (communityId) =>


### PR DESCRIPTION
why
プレイリスト内の任意の楽曲を先頭へ優先表示させるレコメンド機能の実装のため

what
・Playlistsモデルにrecommendカラムを追加
・PlaylistsControllerにrecommendを操作するアクション(create_recommend, destroy_recommend)を追加および既存のプレイリストの返却データを改修(recommend=trueを優先表示)
・フロントエンドにhooksと関数を追加(useRecommend, useUnrecommend, createRecommend, destroyRecommend)


close #45 